### PR TITLE
wip: switching from ip address to node name

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 			l := log.New(os.Stderr, log.INFO, node.Name())
 			defer wg.Done()
 			defer sem.Signal()
-			args := []string{node.PrivateIpAddress}
+			args := []string{node.Name()}
 			args = append(args, cmd...)
 			c := exec.Command("ssh", args...)
 			c.Stderr = l


### PR DESCRIPTION
Since we started doing dns resolution, using ip for the ssh
commands doesn't setup the right user. We _could_ try both on an
error, or hide it behind a resolve flag as well since using
ip seems like it should be an option

@gjohnson @tj what do you guys think? already pushed this branch
on the prod jump host
